### PR TITLE
【bugfix】移動速度のデータが取れていなかったため修正

### DIFF
--- a/client/Assets/Project/Data/PartyTable.yaml
+++ b/client/Assets/Project/Data/PartyTable.yaml
@@ -2,11 +2,11 @@
   formation: [
     [1]
   ]
-  move_speed: 1
+  move_speed: 2.0
 - id: 2
   formation: [
     [1,1,1],
     [1,1,1],
     [1,1,1]
   ]
-  move_speed: 1
+  move_speed: 1.5

--- a/client/Assets/Project/Scripts/Infra/Master/MasterBuilder.cs
+++ b/client/Assets/Project/Scripts/Infra/Master/MasterBuilder.cs
@@ -83,7 +83,7 @@ namespace Omino.Infra.Master
             var text = reader.ReadToEnd();
             var deserializer = new DeserializerBuilder()
                                 .IgnoreUnmatchedProperties()
-                                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                                .WithNamingConvention(UnderscoredNamingConvention.Instance)
                                 .Build();
             return deserializer.Deserialize<List<T>>(text);
         }


### PR DESCRIPTION
## 対応
PartyTableの `move_speed` の数値をマスターデータ変換時に取得できていなかったため、yaml読み込み時の命名ケースをキャメルケースから変更

変換先のデータクラスはどう見てもパスカルケースだか、パスカルケースで設定して読み込むとなぜか失敗していたため、キャメルケースで設定していた。

ちなみにコメントを読む限りではUnderscoreでも変換先はキャメルケースになっているが、パスカルケースな変数に格納できている 🤔 
多分制作側の勘違いか、プロパティの自動定義変数に格納しているかのどちらかだと思うがよくわからない 🤔 🤔 
```
Convert the string from camelcase (thisIsATest) to a underscored (this_is_a_test) string
```